### PR TITLE
feat: more lenient towards different function naming convention

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -151,7 +151,7 @@
 
 ((identifier) @type
   (#lua-match? @type "^[A-Z][a-zA-Z0-9]*$")
-  (#not-has-parent? @type parameter procedure_declaration))
+  (#not-has-parent? @type parameter procedure_declaration call_expression))
 
 ; Fields
 


### PR DESCRIPTION
Some function (specifically in C that are ported/bound to in Odin) have a CamelCase naming convention, currently in a call like `foo.Bar()` they are highlighted as if `Bar` is a type. This PR changes that to be highlighted as a normal function call.