### PR TITLE
Fix: Allow for multiple identifiers before ':' in `named_type`

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -809,7 +809,7 @@ module.exports = grammar({
       '}',
     ),
 
-    named_type: $ => prec.right(seq($.identifier, ':', $.type, optional(seq('=', $.literal)))),
+    named_type: $ => prec.right(seq(commaSep1($.identifier), ':', $.type, optional(seq('=', $.literal)))),
 
     default_type: $ => seq($.identifier, ':=', $.expression),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6483,8 +6483,29 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "SYMBOL",
-            "name": "identifier"
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "identifier"
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "identifier"
+                    }
+                  ]
+                }
+              }
+            ]
           },
           {
             "type": "STRING",


### PR DESCRIPTION
Previously this:
```rust
foo :: proc() -> (x, y: int)
```
would highlight `x` as a type, instead of an identifier.